### PR TITLE
fix: merge options with defaults

### DIFF
--- a/src/image-tracer.ts
+++ b/src/image-tracer.ts
@@ -14,21 +14,21 @@ export class ImageTracer {
    * @param options
    */
   checkOptions(options: ImageTracerOptionsParamers): MaybeImageTracerOptions {
-    let result: MaybeImageTracerOptions = { ...this.optionpresets.default }
+    if (options === undefined) {
+      return { ...this.optionpresets.default }
+    }
     // Option preset
     if (typeof options === 'string') {
       const presetName = options
       const preset = this.optionpresets[presetName]
-      result = preset || {}
+      return { ...this.optionpresets.default, ...(preset || {}) }
     }
 
     if (typeof options === 'object') {
       // Defaults
-      result = { ...options }
+      return { ...this.optionpresets.default, ...options }
     }
-    // options.pal is not defined here, the custom palette should be added externally: options.pal = [ { 'r':0, 'g':0, 'b':0, 'a':255 }, {...}, ... ];
-    // options.layercontainerid is not defined here, can be added externally: options.layercontainerid = 'mydiv'; ... <div id="mydiv"></div>
-    return result
+    throw new Error(`Unknown Option Type: ${typeof options}`)
   }
 
   /**
@@ -38,7 +38,7 @@ export class ImageTracer {
    * @param callback
    * @param options
    */
-  async imageToSVG(url: string, options: ImageTracerOptionsParamers) {
+  async imageToSVG(url: string, options?: ImageTracerOptionsParamers) {
     options = this.checkOptions(options)
     // loading image, tracing and callback
     const canvas = await this.loadImage(url, options)
@@ -56,7 +56,7 @@ export class ImageTracer {
    * @param callback
    * @param options
    */
-  loadImage(url: string, options: MaybeImageTracerOptions): Promise<HTMLCanvasElement> {
+  loadImage(url: string, options?: MaybeImageTracerOptions): Promise<HTMLCanvasElement> {
     return new Promise((resolve) => {
       const img = new Image()
       if (options && options.corsenabled)
@@ -78,7 +78,7 @@ export class ImageTracer {
    * @param imgd
    * @param options
    */
-  imageDataToSVG(imgd: ImageData, options: ImageTracerOptionsParamers) {
+  imageDataToSVG(imgd: ImageData, options?: ImageTracerOptionsParamers) {
     options = this.checkOptions(options)
     // tracing imagedata
     const td = this.imageDataToTracedata(imgd, options)
@@ -93,7 +93,7 @@ export class ImageTracer {
    * @param callback
    * @param options
    */
-  async imageToTracedata(url: string, options: ImageTracerOptionsParamers) {
+  async imageToTracedata(url: string, options?: ImageTracerOptionsParamers) {
     options = this.checkOptions(options)
     // loading image, tracing and callback
     const canvas = await this.loadImage(url, options)
@@ -105,7 +105,7 @@ export class ImageTracer {
    * @param imgd
    * @param options
    */
-  imageDataToTracedata(imgd: ImageData, options: ImageTracerOptionsParamers): Tracedata {
+  imageDataToTracedata(imgd: ImageData, options?: ImageTracerOptionsParamers): Tracedata {
     options = this.checkOptions(options)
     let tracedata: Tracedata
     // 1. Color quantization

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -32,6 +32,8 @@ export const OPTION_PRESETS: ImageTracerOptionsPresets = {
     blurradius: 0,
     blurdelta: 20,
 
+    // options.pal is not defined here, the custom palette should be added externally: options.pal = [ { 'r':0, 'g':0, 'b':0, 'a':255 }, {...}, ... ];
+    // options.layercontainerid is not defined here, can be added externally: options.layercontainerid = 'mydiv'; ... <div id="mydiv"></div>
   },
 
   posterized1: { colorsampling: 0, numberofcolors: 2 },


### PR DESCRIPTION
I was running into an error about an index out of bounds when specifying any options, but the original imageresizerjs was working fine. I compared the source code and eventually tracked down the issue to the options not being merged correctly.

If you see here in the original source 

https://github.com/jankovicsandras/imagetracerjs/blob/fd7252f20e5a832adc326fbe4e88b17530d4747e/imagetracer_v1.2.6.js#L219-L234

The options are meant to get merged with the defaults regardless of whether the user uses a preset or specifies options. This was causing my error because the code checks if options.layering === 0 (the default), but options.layering was undefined, making it go into the options.layering === 1 branch which threw the error.

I cleaned up the code in checkOptions to make this more obvious and moved some comments regarding the defaults to where they're defined.

Additionally the functions were typed such that it forces you to specify options instead of making the parameter properly optional (it is not enough in typescript to say an argument might be undefined to be able to omit it).

